### PR TITLE
Removing deprecated -all-static LDFLAG

### DIFF
--- a/jq.go
+++ b/jq.go
@@ -1,7 +1,7 @@
 package jq
 
 /*
-#cgo LDFLAGS: -ljq -all-static
+#cgo LDFLAGS: -ljq
 #include <jq.h>
 #include <stdlib.h>
 */


### PR DESCRIPTION
 Libtools options were just ignored by gcc, but newer releases do not accept them anymore. This declaration was breaking compilation in debian gcc 4.9.2. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46410
